### PR TITLE
goreleaser bin -> zip

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+project_name: plugins/source/yandex
+
 before:
   hooks:
     - go mod download
@@ -22,7 +24,7 @@ builds:
 archives:
   -
     name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-    format: binary
+    format: zip
 checksum:
   name_template: 'checksums.txt'
 changelog:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ kind: source
 spec:
   # Source spec section
   name: "yandex"
-  version: "v0.3.0"
+  version: "v0.3.1"
   path: "yandex-cloud/yandex"
   destinations: ["postgresql"]
 


### PR DESCRIPTION
cloudquery requires zip archives with file structure "plugins/source/yandex"